### PR TITLE
Allow user to specify path to parameters file on execution

### DIFF
--- a/GB-eaSy.sh
+++ b/GB-eaSy.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 
+PARAMETERS="./GB-eaSy_parameters.txt"
+
+# If a non-default parameters file is supplied, set it as the source of parameters
+if [[ -n "$1" ]]; then
+	PARAMETERS="$1"
+fi
+
 set -e
 set -x
-. ./GB-eaSy_parameters.txt
+. "$PARAMETERS"
 
 ##SET UP DIRECTORY STRUCTURE
 mkdir -p Intermediate_files/1.Demultiplexed_reads Intermediate_files/2.bam_alignments/ Intermediate_files/3.mpileup/ Intermediate_files/4.Raw_SNPs/ Results/


### PR DESCRIPTION
This allows the user to specify a parameter file at runtime instead of having to modify `GB-eaSy.sh`. It assumes the original filename if no file is supplied.

Use Case:
I wanted to set up GB-eaSy as a system-wide tool for a multi-user server, so allowing the user to specify the file without having to modify the system's copy of `GB-eaSy.sh` would make this possible.